### PR TITLE
Do Not Merge: Make `CopyToMap` in Codegen a Hard Error.

### DIFF
--- a/dace/codegen/targets/cuda.py
+++ b/dace/codegen/targets/cuda.py
@@ -211,6 +211,9 @@ class CUDACodeGen(TargetCodeGenerator):
                     except ValueError:  # If transformation doesn't match, continue normally
                         continue
 
+                    else:
+                        raise RuntimeError("Detected the promotion of Memlet '{e}' to a Map inside the code generator.")
+
         # Annotate CUDA streams and events
         self._cuda_streams, self._cuda_events = self._compute_cudastreams(sdfg)
 

--- a/dace/transformation/dataflow/copy_to_map.py
+++ b/dace/transformation/dataflow/copy_to_map.py
@@ -71,6 +71,7 @@ class CopyToMap(xf.SingleStateTransformation):
         return subsets.Range([(ind, ind, 1) for ind in cur_index])
 
     def apply(self, state: SDFGState, sdfg: SDFG):
+
         avnode = self.a
         av = avnode.data
         adesc = avnode.desc(sdfg)


### PR DESCRIPTION
There are several things here at play.
In normal GT4Py, we have to adjust the order of the Map iteration space, this is an artifact of the data layout that we are using, otherwise the strides are not correctly used (memory coalescence), this is why in GT4Py we are doing this by manually.
There is however also a different problem, that leads to launch errors.
Thus, we turn this silent "promotion" of Memlets into Maps into an hard error.

Note:
This fix (which in one way should enter DaCe main anyway) will render the GPU mode of DaCe unusable, at least outside GT4Py.