### PR TITLE
Limit networkx version <= 3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(name='dace',
       },
       include_package_data=True,
       install_requires=[
-          'numpy < 2.0', 'networkx >= 2.5', 'astunparse', 'sympy >= 1.9', 'pyyaml', 'ply',
+          'numpy < 2.0', 'networkx >= 2.5, <= 3.5', 'astunparse', 'sympy >= 1.9', 'pyyaml', 'ply',
           'fparser == 0.2.0', 'aenum >= 3.1', 'dataclasses; python_version < "3.7"', 'dill',
           'pyreadline;platform_system=="Windows"', 'typing-compat; python_version < "3.8"', 'packaging'
       ] + cmake_requires,


### PR DESCRIPTION
Both GT4Py and DaCe CI workflows show compatibility errors with `networkx==3.6`:
- GT4Py daily CI: https://github.com/GridTools/gt4py/actions/runs/19666694049/job/56325414139
- DaCe CI: https://github.com/spcl/dace/actions/runs/19639430452/job/56238635913

This PR applies to the cartesian dace fork the same workaround already applied for next, namely to limit the highest version.